### PR TITLE
add pyyaml requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 cloudmesh.common
 docopt
+pyyaml

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ requiers = """
 cloudmesh.common
 docopt
 requests
+pyyaml
 """.split("\n")
 
 # dependency_links = ['http://github.com/nicolaiarocci/eve.git@develop']


### PR DESCRIPTION
Fresh virtualenv/pyenv fails unless pyyaml is installed.